### PR TITLE
E33 fixes

### DIFF
--- a/Clair Obscur Expedition 33/ClairObscurExpedition33.asl
+++ b/Clair Obscur Expedition 33/ClairObscurExpedition33.asl
@@ -13,6 +13,7 @@ startup
 	vars.Helper.AlertLoadless();
 	vars.TimerModel = new TimerModel { CurrentState = timer };
 	vars.EncounterWon = new List<string>();
+	vars.paksFolder = ""; // read in onStart, so should be initialized
 	vars.allHelpersInitialized = false;
 }
 
@@ -155,9 +156,7 @@ start
 
 	if (!settings["NewGamePlus"])
 	{
-		if ((current.World == "Level_MainMenu" && old.TimePlayed == 0 && current.TimePlayed != 0) 
-		|| current.World == "Level_MainMenu" && current.World != "Level_MainMenu" 
-		&& old.TimePlayed == 0 && current.TimePlayed != 0) return true;
+		if ((current.World == "Level_MainMenu" && old.TimePlayed == 0 && current.TimePlayed > 0 && current.TimePlayed < 10)) return true;
 	}
 	else if (settings["NewGamePlus"])
 	{


### PR DESCRIPTION
* Moving the build version detection to the normal update loop, downside is that the version won't be displayed in the settings editor
* Fixing switch case map still checking for the "(Steam)" string
* AS won't start the timer when loading a save for practice (TimePlayed jumps to the thousands) - the other starting condition was always false

We might need to use the integer build number at some point in the future.

Don't have the GamePass version, or downpatched ones, so cannot check those