### PR TITLE
[Clair Obscur: Expedition 33] Battle load time adjustments

### DIFF
--- a/Clair Obscur Expedition 33/ClairObscurExpedition33.asl
+++ b/Clair Obscur Expedition 33/ClairObscurExpedition33.asl
@@ -14,11 +14,14 @@ startup
 	vars.TimerModel = new TimerModel { CurrentState = timer };
 	vars.EncounterWon = new List<string>();
 	vars.paksFolder = ""; // read in onStart, so should be initialized
-	vars.allHelpersInitialized = false;
 }
 
 init
 {
+	vars.WaitForPlayer = true;
+	vars.WaitForBuild = true;
+	print("Awaiting player...");
+
 	vars.ModsDetected = false;
 	vars.gameModule = modules.First();
 	vars.sandfallLocation = Path.GetFullPath(Path.Combine(vars.gameModule.FileName, @"../../../"));
@@ -40,128 +43,305 @@ init
 	}
 	if (Directory.Exists(vars.paksFolder + @"~mods"))
 	{
-		const string Msg = "Mods detected. Stopping ASL.";
-		throw new Exception(Msg);
+		throw new Exception("Mods detected. Stopping ASL.");
 	}
 
-	IntPtr gWorld = vars.Helper.ScanRel(3, "48 8B 1D ???????? 48 85 DB 74 ?? 41 B0 01");
-	IntPtr gEngine = vars.Helper.ScanRel(3, "48 8B 0D ???????? 66 0F 5A C9 E8");
-	IntPtr fNames = vars.Helper.ScanRel(7, "8B D9 74 ?? 48 8D 15 ???????? EB");
-
-	vars.gEngine = gEngine;
-
-	if (gWorld == IntPtr.Zero || gEngine == IntPtr.Zero || fNames == IntPtr.Zero)
+	vars.TryInit = (Func<bool>)(() =>
 	{
-		const string Msg = "Not all required addresses could be found by scanning.";
-		throw new Exception(Msg);
-	}
+		IntPtr gWorld = vars.Helper.ScanRel(3, "48 8B 1D ???????? 48 85 DB 74 ?? 41 B0 01");
+		IntPtr gEngine = vars.Helper.ScanRel(3, "48 8B 0D ???????? 66 0F 5A C9 E8");
+		IntPtr fNames = vars.Helper.ScanRel(7, "8B D9 74 ?? 48 8D 15 ???????? EB");
 
-	vars.Helper["BuildVersion"] = vars.Helper.MakeString(gEngine, 0x10A8, 0x38, 0x0, 0x30, 0x878, 0x440, 0x1A0, 0x28, 0x0);
-	vars.BuildVersion = "tbd";
-	print("Awaiting build version...");
-
-	vars.FillHelpers = (Action)(()=>{
-		string buildVersion = vars.BuildVersion; // switch needs a nullable variable
-		// GWorld.FName
-		vars.Helper["GWorldName"] = vars.Helper.Make<ulong>(gWorld, 0x18);
-		// GEngine.GameInstance.LocalPlayers[0].IsPauseMenuVisible
-		vars.Helper["IsPauseMenuVisible"] = vars.Helper.Make<bool>(gEngine, 0x10A8, 0x38, 0x0, 0x30, 0xBC8);
-		// GEngine.GameInstance.LocalPlayers[0].IsChangingArea
-		vars.Helper["IsChangingArea"] = vars.Helper.Make<bool>(gEngine, 0x10A8, 0x38, 0x0, 0x30, 0xDE8);
-		// GEngine.GameInstance.LocalPlayers[0].BP_CinematicSystem.LevelSequenceActor.Sequence
-		vars.Helper["CS_CinematicName"] = vars.Helper.Make<ulong>(gEngine, 0x10A8, 0x38, 0x0, 0x30, 0x8A8, 0xA8, 0x290, 0x18);
-		// GEngine.GameInstance.LocalPlayers[0].BP_CinematicSystem.CinematicPaused
-		vars.Helper["CS_CinematicPaused"] = vars.Helper.Make<bool>(gEngine, 0x10A8, 0x38, 0x0, 0x30, 0x8A8, 0x239);
-		// GEngine.GameInstance.LocalPlayers[0].AC_jRPG_BattleManager.EncounterName
-		vars.Helper["BattleManagerEncounterName"] = vars.Helper.Make<ulong>(gEngine, 0x10A8, 0x38, 0x0, 0x30, 0x920, 0x190);
-		// GEngine.GameInstance.LocalPlayers[0].AC_jRPG_BattleManager.BattleEndState
-		vars.Helper["BattleEndState"] = vars.Helper.Make<byte>(gEngine, 0x10A8, 0x38, 0x0, 0x30, 0x920, 0x910);
-		// GEngine.GameInstance.LocalPlayers[0].ExplorationHUDWidget.MiniMapWidget.bIsActive
-		switch(buildVersion)
+		if (gWorld == IntPtr.Zero || gEngine == IntPtr.Zero || fNames == IntPtr.Zero)
 		{
-			case "57661":
-				vars.Helper["MiniMapActive"] = vars.Helper.Make<bool>(gEngine, 0x10A8, 0x38, 0x0, 0x30, 0x980, 0x3D0, 0x368);
-				break;
-			default:
-				vars.Helper["MiniMapActive"] = vars.Helper.Make<bool>(gEngine, 0x10A8, 0x38, 0x0, 0x30, 0x980, 0x3C8, 0x368);
-				break;
-		} 
-		// GEngine.GameInstance.LocalPlayers[0].BattleFlowState
-		vars.Helper["BattleFlowState"] = vars.Helper.Make<byte>(gEngine, 0x10A8, 0x38, 0x0, 0x30, 0x9B0);
-		// GEngine.GameInstance.LocalPlayers[0].IsSavePointMenuVisible
-		vars.Helper["IsSavePointMenuVisible"] = vars.Helper.Make<bool>(gEngine, 0x10A8, 0x38, 0x0, 0x30, 0xBE0);
-		// GEngine.GameInstance.IsChangingMap
-		vars.Helper["IsChangingMap"] = vars.Helper.Make<bool>(gEngine, 0x10A8, 0x1D0);
-		// GEngine.GameInstance.LocalPlayers[0].TimePlayed
-		vars.Helper["TimePlayed"] = vars.Helper.Make<double>(gEngine, 0x10A8, 0x1F0);
-		// GEngine.GameInstance.Loading_Screen_Widget.HasAppeared
-		vars.Helper["LSW_HasAppeared"] = vars.Helper.Make<bool>(gEngine, 0x10A8, 0xB08, 0x300);
-		// GEngine.GameInstance.FinishedGameCount
-		vars.Helper["FinishedGameCount"] = vars.Helper.Make<int>(gEngine, 0x10A8, 0xE4C);
-		// GEngine.GameInstance.PlayerController[0].PlayerCameraManager.CameraCachePrivate.Timestamp
-		vars.Helper["PCMInGame"] = vars.Helper.Make<float>(gEngine, 0x10A8, 0x38, 0x0, 0x30, 0x348, 0x1390);
-
-		vars.allHelpersInitialized = true;
-		print("Helpers set for version: " + buildVersion);
-	});
-
-	vars.FNameToString = (Func<ulong, string>)(fName =>
-	{
-		var nameIdx = (fName & 0x000000000000FFFF) >> 0x00;
-		var chunkIdx = (fName & 0x00000000FFFF0000) >> 0x10;
-		var number = (fName & 0xFFFFFFFF00000000) >> 0x20;
-
-		// IntPtr chunk = vars.Helper.Read<IntPtr>(fNames + 0x10 + (int)chunkIdx * 0x8);
-		IntPtr chunk = vars.Helper.Read<IntPtr>(fNames + 0x10 + (int)chunkIdx * 0x8);
-		IntPtr entry = chunk + (int)nameIdx * sizeof(short);
-
-		int length = vars.Helper.Read<short>(entry) >> 6;
-		string name = vars.Helper.ReadString(length, ReadStringType.UTF8, entry + sizeof(short));
-
-		return number == 0 ? name : name + "_" + number;
-	});
-
-	vars.ReadGuid = (Func<IntPtr, Guid>)(ptr =>
-	{
-		byte[] buffer = new byte[16];
-		for (var i = 0; i < 16; i++)
-		{
-			// buffer[i] = vars.Helper.Read<byte>(gEngine, 0x10A8, 0x38, 0x0, 0x30, 0x8F8, 0xA8, 0x310 + i);
-			buffer[i] = vars.Helper.Read<byte>(ptr + i);
+			return false;
 		}
 
-		return new Guid(buffer);
+		ulong localPlayer = vars.Helper.Read<ulong>(gEngine, 0x10A8, 0x38);
+		if (localPlayer == 0) { // Likely found the wrong game engine due to early startup, so wait a bit
+			return false;
+		}
+
+		// We've found the correct roots, so init is complete
+		print("Game engine with player found");
+		vars.WaitForPlayer = false;
+
+		const LiveSplit.ComponentUtil.MemoryWatcher.ReadFailAction dontUpdate = LiveSplit.ComponentUtil.MemoryWatcher.ReadFailAction.DontUpdate;
+		const LiveSplit.ComponentUtil.MemoryWatcher.ReadFailAction setZeroOrNull = LiveSplit.ComponentUtil.MemoryWatcher.ReadFailAction.SetZeroOrNull;
+
+		const string always = "";
+		const string mainMenu = "BP_jRPG_Controller_MainMenu_C";
+		const string inGame = "BP_jRPG_Controller_World_C";
+		const string inGameWorldMap = "BP_PlayerController_WorldMap_C";
+
+		vars.AllHelpers = new List<string>();
+
+		vars.HelpersForPlayerType = new Dictionary<string, List<string>>();
+		vars.HelpersForPlayerType[mainMenu] = new List<string>();
+		vars.HelpersForPlayerType[inGame] = new List<string>();
+		vars.HelpersForPlayerType[inGameWorldMap] = new List<string>();
+
+		vars.UpdateActionsForPlayerType = new Dictionary<string, List<Action>>();
+		vars.UpdateActionsForPlayerType[mainMenu] = new List<Action>();
+		vars.UpdateActionsForPlayerType[inGame] = new List<Action>();
+		vars.UpdateActionsForPlayerType[inGameWorldMap] = new List<Action>();
+
+		// Player types that have the same memory layouts as others, which may depend on build version
+		vars.PlayerTypeAliases = new Dictionary<string, string>();
+
+		vars.playerWatcher = vars.Helper.Make<ulong>(gEngine, 0x10A8, 0x38);
+		vars.playerWatcher.FailAction = setZeroOrNull;
+		vars.playerTypeWatcher = vars.Helper.Make<ulong>(gEngine, 0x10A8, 0x38, 0x0, 0x30, 0x18);
+		vars.playerTypeWatcher.FailAction = setZeroOrNull;
+
+		// Registers a memory watcher with the Basic as well as the player type dictionary. If the player type is empty, then the watcher is always enabled.
+		vars.RegisterHelper = (Action<string, string, LiveSplit.ComponentUtil.MemoryWatcher.ReadFailAction, LiveSplit.ComponentUtil.MemoryWatcher>)((name, playerType, failAction, ptr) =>
+		{
+			ptr.FailAction = failAction;
+			if (string.IsNullOrEmpty(playerType))
+			{
+				ptr.Enabled = true;
+			}
+			else
+			{
+				ptr.Enabled = false;
+				vars.HelpersForPlayerType[playerType].Add(name);
+			}
+			vars.Helper[name] = ptr;
+			vars.AllHelpers.Add(name);
+		});
+
+		vars.SetActiveHelpers = (Action<string>)((playerType) =>
+		{
+			foreach (KeyValuePair<string, List<string>> entry in vars.HelpersForPlayerType)
+			{
+				entry.Value.ForEach(helperName => {
+					vars.Helper[helperName].Enabled = (playerType == entry.Key);
+
+					// Also zero the values of setZeroOrNull watchers when they watch a different player type
+					if (playerType != entry.Key && vars.Helper[helperName].FailAction == setZeroOrNull)
+					{
+						vars.Helper[helperName].Reset();
+					}
+				});
+			}
+		});
+
+		// Memory watchers that should be installed when first initializing
+		vars.FillStartupHelpers = (Action)(() =>
+		{
+			// GWorld.FName
+			vars.RegisterHelper("GWorldName", always, dontUpdate, vars.Helper.Make<ulong>(gWorld, 0x18));
+			vars.RegisterHelper("BuildVersion", mainMenu, dontUpdate, vars.Helper.MakeString(gEngine, 0x10A8, 0x38, 0x0, 0x30, 0x878, 0x440, 0x1A0, 0x28, 0x0));
+		});
+
+		// Memory watchers that should be installed once the build version is determined
+		vars.FillBuildSpecificHelpers = (Action<string>)((buildVersion) =>
+		{
+			// GEngine.GameInstance.LocalPlayers[0].IsPauseMenuVisible
+			vars.RegisterHelper("IsPauseMenuVisible", inGame, dontUpdate, vars.Helper.Make<bool>(gEngine, 0x10A8, 0x38, 0x0, 0x30, 0xBC8));  
+			// GEngine.GameInstance.LocalPlayers[0].IsChangingArea
+			vars.RegisterHelper("IsChangingArea", inGame, dontUpdate, vars.Helper.Make<bool>(gEngine, 0x10A8, 0x38, 0x0, 0x30, 0xDE8));
+			// GEngine.GameInstance.LocalPlayers[0].BP_CinematicSystem.LevelSequenceActor.Status
+			vars.RegisterHelper("CS_CinematicStatus", inGame, setZeroOrNull, vars.Helper.Make<uint>(gEngine, 0x10A8, 0x38, 0x0, 0x30, 0x8A8, 0xA8, 0x288));
+			// GEngine.GameInstance.LocalPlayers[0].BP_CinematicSystem.LevelSequenceActor.Sequence
+			vars.RegisterHelper("CS_CinematicName", inGame, setZeroOrNull, vars.Helper.Make<ulong>(gEngine, 0x10A8, 0x38, 0x0, 0x30, 0x8A8, 0xA8, 0x290, 0x18));
+			// GEngine.GameInstance.LocalPlayers[0].BP_CinematicSystem.LevelSequenceActor.SerialNumber
+			vars.RegisterHelper("CS_CinematicSerialNumber", inGame, setZeroOrNull, vars.Helper.Make<uint>(gEngine, 0x10A8, 0x38, 0x0, 0x30, 0x8A8, 0xA8, 0x2A8));
+			// GEngine.GameInstance.LocalPlayers[0].BP_CinematicSystem.IsPlayingCinematic
+			vars.RegisterHelper("CS_IsPlayingCinematic", inGame, setZeroOrNull, vars.Helper.Make<bool>(gEngine, 0x10A8, 0x38, 0x0, 0x30, 0x8A8, 0x238));
+			// GEngine.GameInstance.LocalPlayers[0].BP_CinematicSystem.CinematicPaused
+			vars.RegisterHelper("CS_CinematicPaused", inGame, dontUpdate, vars.Helper.Make<bool>(gEngine, 0x10A8, 0x38, 0x0, 0x30, 0x8A8, 0x239));
+			// GEngine.GameInstance.LocalPlayers[0].BP_CinematicSystem.EventBeforePostCinematicTransitionStarted // First field is sufficient for null check
+			vars.RegisterHelper("CS_EventBeforePostCinematicTransitionStarted", inGame, dontUpdate, vars.Helper.Make<ulong>(gEngine, 0x10A8, 0x38, 0x0, 0x30, 0x8A8, 0x298));
+			// GEngine.GameInstance.LocalPlayers[0].AC_jRPG_BattleManager.EncounterName
+			vars.RegisterHelper("BattleManagerEncounterName", inGame, dontUpdate, vars.Helper.Make<ulong>(gEngine, 0x10A8, 0x38, 0x0, 0x30, 0x920, 0x190));
+			// GEngine.GameInstance.LocalPlayers[0].AC_jRPG_BattleManager.BattleEndState
+			vars.RegisterHelper("BattleEndState", inGame, dontUpdate, vars.Helper.Make<byte>(gEngine, 0x10A8, 0x38, 0x0, 0x30, 0x920, 0x910));
+			// GEngine.GameInstance.LocalPlayers[0].ExplorationHUDWidget.MiniMapWidget.bIsActive
+			switch(buildVersion)
+			{
+				case "57661":
+					vars.RegisterHelper("MiniMapActive", inGame, dontUpdate, vars.Helper.Make<bool>(gEngine, 0x10A8, 0x38, 0x0, 0x30, 0x980, 0x3D0, 0x368));
+					break;
+				default:
+					vars.RegisterHelper("MiniMapActive", inGame, dontUpdate, vars.Helper.Make<bool>(gEngine, 0x10A8, 0x38, 0x0, 0x30, 0x980, 0x3C8, 0x368));
+					break;
+			}
+			// GEngine.GameInstance.LocalPlayers[0].BattleFlowState
+			vars.RegisterHelper("BattleFlowState", inGame, dontUpdate, vars.Helper.Make<byte>(gEngine, 0x10A8, 0x38, 0x0, 0x30, 0x9B0));
+			// GEngine.GameInstance.LocalPlayers[0].IsSavePointMenuVisible
+			vars.RegisterHelper("IsSavePointMenuVisible", inGame, dontUpdate, vars.Helper.Make<bool>(gEngine, 0x10A8, 0x38, 0x0, 0x30, 0xBE0));
+			// GEngine.GameInstance.IsChangingMap
+			vars.RegisterHelper("IsChangingMap", inGame, dontUpdate, vars.Helper.Make<bool>(gEngine, 0x10A8, 0x1D0));
+			// GEngine.GameInstance.LocalPlayers[0].TimePlayed
+			vars.RegisterHelper("TimePlayed", inGame, dontUpdate, vars.Helper.Make<double>(gEngine, 0x10A8, 0x1F0));
+			// GEngine.GameInstance.Loading_Screen_Widget.HasAppeared
+			vars.RegisterHelper("LSW_HasAppeared", inGame, dontUpdate, vars.Helper.Make<bool>(gEngine, 0x10A8, 0xB08, 0x300));
+			// GEngine.GameInstance.FinishedGameCount
+			vars.RegisterHelper("FinishedGameCount", inGame, dontUpdate, vars.Helper.Make<int>(gEngine, 0x10A8, 0xE4C));
+			// GEngine.GameInstance.PlayerController[0].PlayerCameraManager.CameraCachePrivate.Timestamp
+			vars.RegisterHelper("PCMInGame", inGame, dontUpdate, vars.Helper.Make<float>(gEngine, 0x10A8, 0x38, 0x0, 0x30, 0x348, 0x1390));
+
+			vars.UpdateActionsForPlayerType[inGame].Add((Action)(() =>
+			{
+				IntPtr dialoguePtr;
+				if (vars.Helper.TryDeref(out dialoguePtr, gEngine, 0x10A8, 0x38, 0x0, 0x30, 0x8F8, 0xA8, 0x310)) current.DialogueGuid = vars.ReadGuid(dialoguePtr);
+				else current.DialogueGuid = Guid.Empty;
+
+				IntPtr battleDebugLastFlowStatePtr;
+				if (vars.Helper.TryDeref(out battleDebugLastFlowStatePtr, gEngine, 0x10A8, 0x38, 0x0, 0x30, 0x920, 0x9D8)) current.BattleDebugLastFlowState = vars.ReadFString(battleDebugLastFlowStatePtr);
+				else current.BattleDebugLastFlowState = "";
+			}));
+
+			vars.PlayerTypeAliases.Add(inGameWorldMap, inGame);
+		});
+
+		vars.FNameToString = (Func<ulong, bool, string>)((fName, includeNumber) =>
+		{
+			var nameIdx = (fName & 0x000000000000FFFF) >> 0x00;
+			var chunkIdx = (fName & 0x00000000FFFF0000) >> 0x10;
+			var number = (fName & 0xFFFFFFFF00000000) >> 0x20;
+
+			IntPtr chunk = vars.Helper.Read<IntPtr>(fNames + 0x10 + (int)chunkIdx * 0x8);
+			IntPtr entry = chunk + (int)nameIdx * sizeof(short);
+
+			int length = vars.Helper.Read<short>(entry) >> 6;
+			string name = vars.Helper.ReadString(length, ReadStringType.UTF8, entry + sizeof(short));
+
+			return includeNumber && number != 0 ? name + "_" + number : name;
+		});
+
+		vars.ReadGuid = (Func<IntPtr, Guid>)(ptr =>
+		{
+			byte[] buffer = new byte[16];
+			for (var i = 0; i < 16; i++)
+			{
+				buffer[i] = vars.Helper.Read<byte>(ptr + i);
+			}
+
+			return new Guid(buffer);
+		});
+
+		vars.ReadFString = (Func<IntPtr, string>)(ptr =>
+		{
+			byte[] buffer = new byte[12];
+			if (!game.ReadBytes(ptr, 12, out buffer)) return "";
+			IntPtr strAddr = new IntPtr(BitConverter.ToInt64(buffer, 0));
+			int length = BitConverter.ToInt32(buffer, 8);
+			if (strAddr == IntPtr.Zero || length < 1) return "";
+			return vars.Helper.ReadString(2*length, ReadStringType.UTF16, strAddr);
+		});
+
+		vars.WaitForBuild = true;
+		print("Awaiting build version...");
+
+		vars.FillStartupHelpers();
+
+		vars.ActivePlayerTypeFName = 0UL;
+		vars.ActivePlayerType = "";
+		vars.SetActiveHelpers("");
+
+		current.World = "";
+		current.EncounterName = "";
+		current.BattleDebugLastFlowState = "";
+		current.CurrentCinematic = "";
+		current.BattleEndState = 0;
+		current.FinishedGameCount = 0;
+		current.IsSavePointMenuVisible = false;
+		current.WorldMapMiniMap = false;
+		current.TimePlayed = 0;
+		current.DialogueGuid = Guid.Empty;
+		vars.BattleWon = false;
+		vars.HasEnteredWorldMap = false;
+
+		vars.EvequeEncounters = new HashSet<string>() { "SM_Eveque_ShieldTutorial*1", "SM_Eveque*1" };
+		vars.CuratorEncounters = new HashSet<string>() { "GO_Curator_JumpTutorial*1", "GO_Curator_JumpTutorial_NoTuto*1" };
+
+		return true;
 	});
+}
 
-	current.World = "";
-	current.EncounterName = "";
-	current.CurrentCinematic = "";
-	current.BattleEndState = 0;
-	current.FinishedGameCount = 0;
-	current.IsSavePointMenuVisible = false;
-	current.WorldMapMiniMap = false;
-	current.TimePlayed = 0;
-	current.DialogueGuid = Guid.Empty;
-	vars.BattleWon = false;
-	vars.HasEnteredWorldMap = false;
+update
+{
+	if (vars.WaitForPlayer)
+	{
+		if (!vars.TryInit()) return false;
+		vars.WaitForPlayer = false;
+		vars.WaitForBuild = true;
+	}
 
-	vars.EvequeEncounters = new HashSet<string>() { "SM_Eveque_ShieldTutorial*1", "SM_Eveque*1" };
-	vars.CuratorEncounters = new HashSet<string>() { "GO_Curator_JumpTutorial*1", "GO_Curator_JumpTutorial_NoTuto*1" };
+	vars.playerWatcher.Update(game);
+	if (vars.playerWatcher.Current == 0) // Quitting
+	{
+		timer.IsGameTimePaused = true;
+		return false;
+	}
+
+	vars.playerTypeWatcher.Update(game);
+	ulong playerTypeFName = vars.playerTypeWatcher.Current;
+	if (playerTypeFName != vars.ActivePlayerTypeFName) // Optimization
+	{
+		vars.ActivePlayerTypeFName = playerTypeFName;
+		vars.ActivePlayerType = vars.FNameToString(vars.ActivePlayerTypeFName, false);
+		while (vars.PlayerTypeAliases.ContainsKey(vars.ActivePlayerType)) vars.ActivePlayerType = vars.PlayerTypeAliases[vars.ActivePlayerType];
+		vars.SetActiveHelpers(vars.ActivePlayerType);
+	}
+
+	vars.Helper.Update();
+	vars.Helper.MapPointers();
+
+	if (vars.WaitForBuild)
+	{
+		string buildVersion = current.BuildVersion;
+		if (!string.IsNullOrEmpty(buildVersion) && buildVersion.All(char.IsDigit) && buildVersion != "999999")
+		{
+			print("Detected build: " + buildVersion);
+			vars.FillBuildSpecificHelpers(buildVersion);
+			vars.WaitForBuild = false;
+			print("Installed build-specific memory watchers");
+		}
+		return false; // If we just captured the build version, then we'll update all the newly registered helpers on the next tick
+	}
+
+	// We have a build version and helpers for the player type have updated, so we can now safely perform most update calculations.
+
+	if (vars.ModsDetected)
+	{
+		vars.TimerModel.Reset();
+		return false;
+	}
+
+	if (vars.UpdateActionsForPlayerType.ContainsKey(vars.ActivePlayerType))
+	{
+		foreach (Action action in vars.UpdateActionsForPlayerType[vars.ActivePlayerType]) action?.Invoke();
+	}
+
+	var world = vars.FNameToString(current.GWorldName, true);
+	if (!string.IsNullOrEmpty(world) && world != "None") current.World = world;
+
+	if (!vars.HasEnteredWorldMap && current.World == "Level_WorldMap_Main_V2") vars.HasEnteredWorldMap = true;
+	if (old.BattleEndState == 0 && current.BattleEndState == 1) vars.BattleWon = true;
+
+	var encounter = vars.FNameToString(current.BattleManagerEncounterName, true);
+	if (!string.IsNullOrEmpty(encounter) && current.World != "Level_MainMenu") current.EncounterName = encounter;
+
+	if (current.CS_CinematicName == 0) current.CurrentCinematic = "";
+	else current.CurrentCinematic = vars.FNameToString(current.CS_CinematicName, true);
 }
 
 start
 {
-	if (!vars.allHelpersInitialized) return false;
+	if (vars.WaitForBuild) return false;
 
 	if (!settings["NewGamePlus"])
 	{
-		if ((current.World == "Level_MainMenu" && old.TimePlayed == 0 && current.TimePlayed > 0 && current.TimePlayed < 10)) return true;
+		if (((current.World == "Level_MainMenu" || current.World == "Level_Lumiere_Main_V2") && old.TimePlayed == 0 && current.TimePlayed > 0 && current.TimePlayed < 10)) return true;
 	}
 	else if (settings["NewGamePlus"])
 	{
 		if (old.CurrentCinematic != current.CurrentCinematic && current.CurrentCinematic.Contains("MCS_MyFlower")) return true;
 	}
-
 }
 
 onStart
@@ -184,8 +364,7 @@ onStart
 	if (Directory.Exists(vars.paksFolder + @"~mods"))
 	{
 		vars.ModsDetected = true;
-		const string Msg = "Mods detected. Stopping ASL.";
-		throw new Exception(Msg);
+		throw new Exception("Mods detected. Stopping ASL.");
 	}
 	timer.IsGameTimePaused = true;
 	vars.BattleWon = false;
@@ -193,73 +372,49 @@ onStart
 	vars.EncounterWon.Clear();
 }
 
-update
-{
-	vars.Helper.Update();
-	vars.Helper.MapPointers();
-
-	if (vars.ModsDetected) vars.TimerModel.Reset();
-
-	if (!vars.allHelpersInitialized)
-	{
-		string buildVersion = (current.BuildVersion != null) ? current.BuildVersion.ToString() : "";
-
-		// Exclude "999999" and check for a non-empty, numeric buildVersion
-		if (string.IsNullOrEmpty(buildVersion) || !buildVersion.All(char.IsDigit) || buildVersion == "999999")
-		{
-			// Not detected
-			return;
-		}
-		print("Detected Build Version: " + buildVersion);
-
-		switch(buildVersion)
-		{
-			case "57661":
-				vars.BuildVersion = "57661";
-				break;
-			default:
-				vars.BuildVersion = "<=57069";
-				break;
-		}
-		vars.FillHelpers();
-
-		return;
-	}
-
-	// Dialogue
-	IntPtr dialoguePtr;
-	if (vars.Helper.TryDeref(out dialoguePtr, vars.gEngine, 0x10A8, 0x38, 0x0, 0x30, 0x8F8, 0xA8, 0x310)) current.DialogueGuid = vars.ReadGuid(dialoguePtr);
-	else current.DialogueGuid = Guid.Empty;
-
-	if (!vars.HasEnteredWorldMap && current.World == "Level_WorldMap_Main_V2") vars.HasEnteredWorldMap = true;
-	if (old.BattleEndState == 0 && current.BattleEndState == 1) vars.BattleWon = true;
-
-	var world = vars.FNameToString(current.GWorldName);
-	if (!string.IsNullOrEmpty(world) && world != "None") current.World = world;
-	if (old.World != current.World)vars.Log(current.World);
-
-	var encounter = vars.FNameToString(current.BattleManagerEncounterName);
-	if (!string.IsNullOrEmpty(encounter) && current.World != "Level_MainMenu") current.EncounterName = encounter;
-	if (old.EncounterName != current.EncounterName) vars.Log("Encounter Name: " + old.EncounterName + " -> " + current.EncounterName);
-
-	var cinematic = vars.FNameToString(current.CS_CinematicName);
-	if (!string.IsNullOrEmpty(cinematic)) current.CurrentCinematic = cinematic;
-
-	// if (old.DialogueGuid != current.DialogueGuid) vars.Log("Current Dialogue GUID is: " + current.DialogueGuid.ToString());
-}
 
 isLoading
 {
-	if (!vars.allHelpersInitialized) return true; // stays paused during boot up after game crash
-	return current.IsChangingMap || current.IsChangingArea || current.CS_CinematicPaused ||
-			(current.World != "Level_MainMenu" && current.PCMInGame < 0.5)  || current.BattleFlowState == 1 || 
-			current.LSW_HasAppeared || (vars.HasEnteredWorldMap && current.MiniMapActive) || 
-			current.World == "Map_Game_Bootstrap" || current.World == "Level_MainMenu";
+	if (vars.WaitForBuild) return true; // stays paused during boot up after game crash
+
+	return
+		current.World == "Map_Game_Bootstrap" || current.World == "Level_MainMenu" || // Startup
+		current.IsChangingMap || current.IsChangingArea || current.LSW_HasAppeared || // Visible loading screens
+		(current.World != "Level_MainMenu" && current.PCMInGame < 0.5) ||
+
+		// Hidden loading screen during post-processed freeze-frame before a battle:
+		(current.BattleFlowState == 2 && (
+			current.BattleDebugLastFlowState == "InitBattle"
+			|| current.BattleDebugLastFlowState == "LoadDependencies"
+			|| current.BattleDebugLastFlowState == "Dependencies loaded"
+		)) ||
+
+		// Cinematic stuff:
+		(current.CS_IsPlayingCinematic && (
+			current.CS_CinematicPaused || // Cinematic paused by player, ready to skip
+			(
+				// Certain cutscene segments hide expensive asset loads. Cannot write a general rule, so we list them explicitly as they are found:
+				current.CS_CinematicStatus == 0 // Current cinematic sequence is stopped (distinct from paused)
+				&& (
+					(current.CurrentCinematic == "MCS_GobluOutro" && current.CS_CinematicSerialNumber == 3 && current.CS_EventBeforePostCinematicTransitionStarted != 0) ||
+					(current.CurrentCinematic == "MCS_PostDuallist" && current.CS_CinematicSerialNumber == 3 && current.CS_EventBeforePostCinematicTransitionStarted != 0) ||
+					(current.CurrentCinematic == "MCS_DiscoveringTheTruth_P2" && current.CS_CinematicSerialNumber == 3 && current.CS_EventBeforePostCinematicTransitionStarted != 0) ||
+					(current.CurrentCinematic == "CS_GPE_MonolithInterior_Locomotive_MonocoToLumiere" && current.CS_CinematicSerialNumber == 3 && current.CS_EventBeforePostCinematicTransitionStarted != 0) ||
+					(current.CurrentCinematic == "CS_CleasFlyingHouse_DuallisteDeath" && current.CS_CinematicSerialNumber == 3 && current.CS_EventBeforePostCinematicTransitionStarted != 0) ||
+					(current.CurrentCinematic == "CS_CleasFlyingHouse_EvequeDeath" && current.CS_CinematicSerialNumber == 3 && current.CS_EventBeforePostCinematicTransitionStarted != 0) ||
+					(current.CurrentCinematic == "CS_CleasFlyingHouse_GobluDeath" && current.CS_CinematicSerialNumber == 3 && current.CS_EventBeforePostCinematicTransitionStarted != 0) ||
+					(current.CurrentCinematic == "CS_CleasFlyingHouse_LampmasterDeath" && current.CS_CinematicSerialNumber == 3 && current.CS_EventBeforePostCinematicTransitionStarted != 0) ||
+					(current.CurrentCinematic == "MCS_MirrorCleaOutro" && current.CS_CinematicSerialNumber == 3 && current.CS_EventBeforePostCinematicTransitionStarted != 0)
+				)
+			)
+		)) ||
+
+		(vars.HasEnteredWorldMap && current.MiniMapActive); // World map open
 }
 
 split
 {
-	if (!vars.allHelpersInitialized) return false;
+	if (vars.WaitForBuild) return false;
 
 	string worldEncounter = current.World + "-" + old.EncounterName;
 
@@ -308,11 +463,11 @@ split
 	{
 		vars.EncounterWon.Add(worldEncounter);
 		vars.BattleWon = false;
-		if (settings[worldEncounter]) return true;
+		if (settings.ContainsKey(worldEncounter) && settings[worldEncounter]) return true;
 	}
 
 	// Act Splits
-	if (old.CurrentCinematic != current.CurrentCinematic)
+	if (old.CurrentCinematic != current.CurrentCinematic && !string.IsNullOrEmpty(current.CurrentCinematic))
 	{
 		if (settings.ContainsKey(current.CurrentCinematic)) return settings[current.CurrentCinematic];
 	}
@@ -320,11 +475,16 @@ split
 
 reset
 {
-    if (settings["AutoReset"] && old.World != "Level_MainMenu" && current.World == "Level_MainMenu") return true;
+	if (vars.WaitForBuild) return false;
+	if (settings["AutoReset"] && old.World != "Level_MainMenu" && current.World == "Level_MainMenu") return true;
 }
 
 exit
 {
-	vars.allHelpersInitialized = false;
 	timer.IsGameTimePaused = true;
+
+	vars.WaitForPlayer = true;
+	((List<string>)vars.AllHelpers).ForEach(helperName => {
+		vars.Helper.RemoveWatcher(helperName);
+	});
 }


### PR DESCRIPTION
This commit makes many changes to the Clair Obscur: Expedition 33 autosplitter. See [#lrt-autosplitter-dev](https://discord.com/channels/1346530304352845906/1366853258198388746) in the Clair Obscur Speedrunning Discord for the analysis and history behind these changes.

Major changes in this commit:

- LRT now pauses during the "wavy" screen at the start of combat, where the game freezes a frame and performs post-processing effects (e.g., zoom or distortion) ending with petals radially sweeping the screen to transition to combat. This is actually the hidden loading screen for battles, and it differs by hardware. This commit detects the state by reading a debugging FString in the `BattleManager` called `DebugLastFlowState`.
- LRT no longer pauses during the "camera twirl" that precedes the "wavy" screen when starting a battle by touching or attacking an enemy. This is simply a matter of removing the `current.BattleFlowState == 1` check in `isLoading`. This screen is not actually a loading screen: it is always 1.557s for touches and 1.967s for attacks.
- Now removes multiple hidden loads that occur just before cutscene outros. These cannot be safely detected universally, so we look for specific segments that are known to be hidden loads. These are:
  - a black screen after defeating Goblu in Flying Waters;
  - a black screen after defeating Dualliste in Forgotten Battlefield;
  - a black screen just before regaining control of Maelle in Old Lumiere;
  - a black screen after the train cutscene in Tainted Hearts; and
  - black screens following all five boss encounters in Flying Manor.
- Adjusted the start condition for New Game to also detect the `Level_Lumiere_Main_V2` world, since the condition is only true for `Level_MainMenu` for one frame, typically. This was necessary because of the refactor, which adds additional delay to find the `LocalPlayer`.
- **Major code refactor**. This commit refactors the code due to three critical issues with the previous implementation:
  1. During early game bootstrapping, the `ScanRel` may find the wrong `GameEngine`, which renders the autosplitter helpless until a restart.
  2. During early game bootstrapping, the `LocalPlayer` might not exist yet.
  3. The `PlayerController` assigned to the `LocalPlayer` changes throughout the game, and different `PlayerController` subclasses have different memory layouts, so it is not safe to follow pointer chains through them without first checking the active `PlayerController` type.

  The refactor addresses these issues with several changes:
  - Initialization code is mostly moved out of `init` and into a helper called `TryInit` that is run within `update` until it succeeds. This allows us to wait until the game has finished bootstrapping and we have found a `GameEngine` with an active `LocalPlayer`.
  - We organize every `Pointer` tracked by `asl-help` into different categories for each `PlayerController` subclass, tracked in `vars.HelpersForPlayerType`. During each `update`, we first check the current `PlayerController` class. If it has changed, we enable or disable the appropriate helpers based on the type before calling `vars.Helper.Update()`. This avoids illegal memory accesses based on the wrong `PlayerController` subclass.
- Added a check that `settings[worldEncounter]` exists before accessing it, which clears up a debug error.