### PR TITLE
Expedition 33 additional splits

### DIFF
--- a/Clair Obscur Expedition 33/ClairObscurExpedition33.Splits.xml
+++ b/Clair Obscur Expedition 33/ClairObscurExpedition33.Splits.xml
@@ -54,6 +54,9 @@
                 <Setting Id="Level_OldLumiere_Main-OL_MirrorRenoir_FirstFight" Label="Renoir" State="true" />
             </Setting>
             <Setting Id="Level_Visages_Main_V1-Visages" Label="Visages" State="true">
+                <Setting Id="Level_Visages_Main_V1-MF_JOY_Moissonneuse_MaskJoy*3_1" Label="Joy Mask" State="false" />
+                <Setting Id="Level_Visages_Main_V1-MF_SADNESS_Chapelier_MaskSadness*3" Label="Sadness Mask" State="false" />
+                <Setting Id="Level_Visages_Main_V1-MF_ANGRY_BoucheclierMaskAnger*3_1" Label="Anger Mask" State="false" />
                 <Setting Id="Level_Visages_Main_V1-MF_Axon_Visages" Label="Mask Keeper" State="true" />
             </Setting>
             <Setting Id="Level_Sirene_Main_V2" Label="Sirène" State="true">
@@ -75,6 +78,17 @@
                 <Setting Id="Level_Lumiere_Main_V2-FinalBossMaelle" Label="Maelle" State="true" />
             </Setting>
         </Setting>
+    </Setting>
+    <Setting Id="PositionSplits" Label="Splits on entering / leaving locations (leaving unless noted)" State="false">
+        <Setting Id="Level_SpringMeadows_Main_V2-worldLeave" Label="Spring Meadows" State="false" />
+        <Setting Id="Level_Goblu_Main_V5-worldLeave" Label="Flying Water (Goblu skip)" State="true" />
+        <Setting Id="Level_AncientSanctuary_Main_V2-worldLeave" Label="Ancient Sanctuary" State="false" />
+        <Setting Id="Level_Main_GestralVillage_V2-worldLeave" Label="Gestral Village" State="false" />
+        <Setting Id="LevelMain_EsquieNest-worldLeave" Label="Esquie's Nest" State="true" />
+        <Setting Id="Level_Main_ForgottenBattlefield_V2-worldLeave" Label="Forgotten Battlefield (Dualliste skip)" State="true" />
+        <Setting Id="Level_MonocoStation-worldLeave" Label="Monoco's Station" State="false" />
+        <Setting Id="Level_OldLumiere_Main-worldLeave" Label="Old Lumière" State="false" />
+        <Setting Id="Level_Visages_Main_V1-worldEnter" Label="Visages (enter)" State="true" />
     </Setting>
     <Setting Id="OptionalEncounterSplits" Label="Optional Encounter Splits" State="false">
         <Setting Id="Level_WorldMap_Main_V2-OE" Label="World Map" State="false">

--- a/Clair Obscur Expedition 33/ClairObscurExpedition33.Splits.xml
+++ b/Clair Obscur Expedition 33/ClairObscurExpedition33.Splits.xml
@@ -45,6 +45,7 @@
                 <Setting Id="Level_Main_ForgottenBattlefield_V2-FB_Chalier_GradientCounterTutorial*1" Label="Chalier" State="false" />
                 <Setting Id="Level_Main_ForgottenBattlefield_V2-FB_DuallisteLR" Label="Dualliste" State="true" />
             </Setting>
+            <Setting Id="Level_WorldMap_Main_V2-WM_Troubadour_Gault_Demineur" Label="(World Map) Troubadour, Gault &amp; Demineur" State="false" />
             <Setting Id="Level_MonocoStation" Label="Monoco's Station" State="true">
                 <Setting Id="Level_MonocoStation-MS_Monoco" Label="Monoco" State="true" />
                 <Setting Id="Level_MonocoStation-MM_Stalact_GradientAttackTutorial*1" Label="Stalact" State="true" />
@@ -65,6 +66,7 @@
             </Setting>
             <Setting Id="TheMonolith" Label="The Monolith" State="true">
                 <Setting Id="FakePaintress" Label="Fake Paintress" State="false" />
+                <Setting Id="CS_GPE_MonolithInterior_Locomotive_MonocoToLumiere" Label="Train cutscene" State="false" />
                 <Setting Id="Level_Monolith_Interior_Climb_Main-MM_MirrorRenoir" Label="Renoir" State="true" />
                 <Setting Id="Level_Monolith_Exterior_Peak_Main-L_Boss_Paintress_P1_Phase1" Label="The Paintress Phase 1" State="false" />
                 <Setting Id="Level_Monolith_Exterior_Peak_Main-L_Boss_Paintress_P1" Label="The Paintress Phase 2" State="true" />
@@ -72,6 +74,7 @@
         </Setting>
         <Setting Id="Act3" Label="Act 3" State="true">
             <Setting Id="Level_Lumiere_Main_V2-Act3" Label="Return To Lumière" State="true">
+                <Setting Id="MCS_TomorrowComes" Label="Entering Lumiere (cutscene)" State="false" />
                 <Setting Id="Level_Lumiere_Main_V2-L_Boss_Curator_P1_Phase1" Label="Renoir Phase 1" State="false" />
                 <Setting Id="Level_Lumiere_Main_V2-L_Boss_Curator_P1" Label="Renoir Phase 2" State="true" />
                 <Setting Id="Level_Lumiere_Main_V2-FinalBossVerso" Label="Verso" State="true" />

--- a/Clair Obscur Expedition 33/ClairObscurExpedition33.asl
+++ b/Clair Obscur Expedition 33/ClairObscurExpedition33.asl
@@ -15,6 +15,7 @@ startup
 	vars.Helper.AlertLoadless();
 	vars.TimerModel = new TimerModel { CurrentState = timer };
 	vars.EncounterWon = new List<string>();
+	vars.WorldTransitionsEncountered = new List<string>();
 	vars.paksFolder = ""; // read in onStart, so should be initialized
 }
 
@@ -382,6 +383,7 @@ onStart
 	vars.BattleWon = false;
 	vars.HasEnteredWorldMap = false;
 	vars.EncounterWon.Clear();
+	vars.WorldTransitionsEncountered.Clear();
 }
 
 
@@ -476,6 +478,22 @@ split
 		vars.EncounterWon.Add(worldEncounter);
 		vars.BattleWon = false;
 		if (settings.ContainsKey(worldEncounter) && settings[worldEncounter]) return true;
+	}
+
+	// Leaving World splits
+	string worldTransition = old.World + "-worldLeave";
+	if ((current.World == "Level_Camp_Main" || current.World == "Level_WorldMap_Main_V2") && !vars.WorldTransitionsEncountered.Contains(worldTransition))
+	{
+		vars.WorldTransitionsEncountered.Add(worldTransition);
+		if (settings.ContainsKey(worldTransition) && settings[worldTransition]) return true;
+	}
+
+	// Entering World splits
+	worldTransition = current.World + "-worldEnter";
+	if (old.World == "Level_WorldMap_Main_V2" && !vars.WorldTransitionsEncountered.Contains(worldTransition))
+	{
+		vars.WorldTransitionsEncountered.Add(worldTransition);
+		if (settings.ContainsKey(worldTransition) && settings[worldTransition]) return true;
 	}
 
 	// Act Splits


### PR DESCRIPTION
Adding some more splits that are useful for restricted and also glitchless.

* Added ability for the asl to split on entering or leaving areas (some of which are splits in restricted)
* Added splits for masks in Visages
* Added split for world fight before Monoco's Station (restricted, expert glitchless)
* Cutscene splits for Monolith and Act 3

Couldn't find your revised ASL, so this is against `main`